### PR TITLE
Use lists for broadcast

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -95,6 +95,9 @@ class AttentionMetadata:
             for field in fields(self) if field.name not in skip_fields
         }
 
+    def values_list(self) -> List[Any]:
+        return [getattr(self, field.name) for field in fields(self)]
+
 
 T = TypeVar("T", bound=AttentionMetadata)
 

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, Dict, List, Optional, Set, Tuple, Type
 
 import flashinfer
@@ -137,6 +137,15 @@ class FlashInferMetadata(AttentionMetadata):
         # broadcasted with nccl when TP is enabled.
         skip_fields.add('decode_wrapper')
         return super().asdict_zerocopy(skip_fields)
+
+    def values_list(self) -> List[Any]:
+        # We need to skip the decode_wrapper field since it cannot be
+        # broadcasted with nccl when TP is enabled.
+        return [
+            getattr(self, field.name)
+            if field.name != 'decode_wrapper' else None
+            for field in fields(self)
+        ]
 
     @property
     def prefill_metadata(self) -> Optional["FlashInferMetadata"]:


### PR DESCRIPTION
Avoid sending all the dict keys, and the calling code also ends up simpler.

`broadcast_tensor_dict` changed to use the list implementation, so there's still an option for calling code to use that too.

Measured end-to-end performance gain from the saved data transfer is negligible however (at least for TP=2 llama-2-7b).

This PR is based on top of #4844.